### PR TITLE
Reset current container if the current container has been removed.

### DIFF
--- a/ReactSkia/core_modules/RSkSpatialNavigator.cpp
+++ b/ReactSkia/core_modules/RSkSpatialNavigator.cpp
@@ -84,6 +84,9 @@ void RSkSpatialNavigator::updateSpatialNavigatorState(NavigatorStateOperation op
                 sendNotificationWithEventType("blur", currentFocus_->getComponentData().tag, completeCallback_);
                 currentFocus_ = nullptr;
             }
+            if(currentContainer_ == candidate) { // reset current container if the container itself is removed
+              currentContainer_ = nullptr;
+            }
             break;
         case ComponentUpdated: // Called when the candidate is not focusable anymore
             if (currentFocus_ == candidate) {

--- a/ReactSkia/core_modules/RSkSpatialNavigatorContainer.cpp
+++ b/ReactSkia/core_modules/RSkSpatialNavigatorContainer.cpp
@@ -51,6 +51,11 @@ void Container::removeComponent(RSkComponent *candidate) {
     RSkSpatialNavigator::sharedSpatialNavigator()->updateSpatialNavigatorState(ComponentRemoved, candidate);
     navComponentList_.erase(it);
   }
+#if  (!defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO))
+  auto containerCandidate = static_cast<RSkComponent*>(this);
+  RNS_LOG_DEBUG("Removed " << candidate->getComponentData().componentName << "[" << candidate->getComponentData().tag << "]" <<
+                " from container : " << containerCandidate->getComponentData().componentName  << "[" << containerCandidate->getComponentData().tag << "]");
+#endif
 }
 
 void Container::updateComponent(RSkComponent *candidate) {
@@ -99,6 +104,11 @@ RSkComponent* Container::preferredFocusInContainer() {
   RSkComponent *preferredFocus = nullptr;
   std::vector<RSkComponent*>::reverse_iterator i;
   CandidateList &navCompList = navComponentList_;
+
+#if  (!defined(GOOGLE_STRIP_LOG) || (GOOGLE_STRIP_LOG <= INFO))
+  auto containerCandidate = static_cast<RSkComponent*>(this);
+  RNS_LOG_DEBUG("Find preferred component in container : " << containerCandidate->getComponentData().componentName  << "[" << containerCandidate->getComponentData().tag << "] of size " << navComponentList_.size());
+#endif
 
   for (i = navCompList.rbegin(); i != navCompList.rend(); ++i ) {
     preferredFocus = *i;


### PR DESCRIPTION
Fixed : When a component which is currentContainer, it was not reset and becoming dangling. Minor debug logs added.

<!--
Hi there and thank you for your change proposal!

Please fill out the following template to make the review process
as quick and smooth as possible.
-->

## Description

Fixes crash when the current navigation container itself removed from the app.
Minor logging changes

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| Linux   |    ✅     |
| iOS     |    ❌     |
| Android |    ❌     |
| Windows |    ❌     |

## Checklist

<!-- Check completed item: [X] -->

* [x] I have tested this on a desktop/device/simulator for each compatible OS
* [ ] I added the documentation in `README.md`
* [ ] I updated the typings files (`privateTypes.ts`, `types.ts`)
* [ ] I added a sample use of the API (`example/App.js`)
